### PR TITLE
new slimmed version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,34 @@ cd snap-erigon
 snapcraft pack --use-lxd --debug --verbosity=debug # Takes some time.
 ```
 
+The snap currently ships all binaries (this will probably change in the future): 
+* abigen 
+* bootnode 
+* capcli 
+* caplin 
+* debug  
+* devnet  
+* downloader  
+* erigon  
+* erigoncustom  
+* evm	
+* hack  
+* integration  
+* observer  
+* p2psim  
+* pics  
+* rlpdump  
+* rpcdaemon  
+* rpctest	
+* sentinel  
+* sentry  
+* silkworm_api	
+* snapshots  
+* state  
+* txpool  
+* verkle
+
+
 ## Releasing
 
 When a commit is made to the main branch a build will start in launchpad and if successful release to the edge channel.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The snap currently ships all binaries (this will probably change in the future):
 * debug  
 * devnet  
 * downloader  
-* erigon  
+* erigon         ->  /var/snap/current/bin/erigon
 * erigoncustom  
 * evm	
 * hack  

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,7 +48,20 @@ parts:
       craftctl default
       craftctl set version="2.59.3-$(git rev-parse --short HEAD)"
     organize:
-      erigon: bin/erigon   
+      erigon: bin/erigon
+
+    override-build: |
+      # The Makefile contains bunch of compiler options. Don't even try reproduce it.
+      go mod tidy
+      make all
+      make DIST=$SNAPCRAFT_PART_INSTALL install
+      mkdir -p $SNAPCRAFT_PART_INSTALL/lib/
+      find /root/go/pkg/mod/github.com/erigontech/ -name libsilkworm_capi.so -exec cp {} $SNAPCRAFT_PART_INSTALL/lib/ \;
+
+    # We only ship these binaries:
+    stage:
+      - bin/*
+      - lib/libsilkworm_capi.so
 
   wrappers:
     plugin: dump
@@ -75,3 +88,6 @@ apps:
     environment:
       LC_ALL: C.UTF-8
       LANG: C.UTF-8
+
+environment:
+  LD_LIBRARY_PATH: "$SNAP/lib:$LD_LIBRARY_PATH"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,67 +39,16 @@ description: |
   Check logs from the erigon service with 'snap logs erigon -f'
 
 parts:
-  go-deps:
-    plugin: nil
-    build-packages:
-    - curl
-    - tar
-    - golang
-    override-pull: |
-      GO_VERSION="1.20"
-      GO_ROOT=/usr/local/go
-      GO_PATH=$HOME/go
-      GO_BINARY=$GO_ROOT/bin/go
-      rm -rf $GO_ROOT  
-      curl -L "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o /tmp/go${GO_VERSION}.linux-amd64.tar.gz
-      tar -C /usr/local -xzf /tmp/go${GO_VERSION}.linux-amd64.tar.gz
-      export GOROOT=$GO_ROOT
-      export GOPATH=$GO_PATH
-      export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
-      $GO_BINARY version
   erigon:
-    after: [go-deps,wrappers]
     plugin: go
+    build-snaps: [go/latest/stable]
     source: https://github.com/ledgerwatch/erigon.git
     source-tag: v2.59.3
-    build-packages:
-      - build-essential
-      - libssl-dev
-      - git
-      - clang
-      - libclang-dev
-      - pkg-config
-      - protobuf-compiler
-      - make
     override-pull: |
-      export GOPATH=$HOME/go
-      export PATH=$PATH:$GOPATH/bin
-      export GO_VERSION="1.20"
-      export GOROOT=/usr/local/go
-      export GO_BINARY=$GOROOT/bin/go
-      go version
-      git clone https://github.com/ledgerwatch/erigon.git $SNAPCRAFT_PART_SRC
-      cd $SNAPCRAFT_PART_SRC
-      git checkout v2.59.3 
+      craftctl default
       craftctl set version="2.59.3-$(git rev-parse --short HEAD)"
-      $GO_BINARY mod tidy
-    override-build: |
-      export GOROOT=/usr/local/go
-      export GOPATH=$HOME/go
-      export PATH=$GOROOT/bin:$GOPATH/bin:$PATH
-      cd $SNAPCRAFT_PART_SRC
-      go mod tidy
-      make all
-      make DIST=$SNAPCRAFT_PART_INSTALL install
-      mkdir -p $SNAPCRAFT_PART_INSTALL/lib/
-      if [ ! -f $SNAPCRAFT_PART_INSTALL/lib/libsilkworm_capi.so ]; then
-        mv $SNAPCRAFT_PART_INSTALL/libsilkworm_capi.so $SNAPCRAFT_PART_INSTALL/lib/
-      fi
     organize:
       erigon: bin/erigon   
-    prime:
-      - '*'
-      - bin/*
 
   wrappers:
     plugin: dump


### PR DESCRIPTION
* Remove all the manual steps.
* Remove unused package deps.
* Still missing ./go/pkg/mod/github.com/erigontech/silkworm-go@v0.14.0/lib/linux_x64/libsilkworm_capi.so
